### PR TITLE
Make registration code toggleable

### DIFF
--- a/xiloader/main.cpp
+++ b/xiloader/main.cpp
@@ -38,6 +38,7 @@ std::string g_Username = ""; // The username being logged in with.
 std::string g_Password = ""; // The password being logged in with.
 std::string g_Discord = ""; // The optional Discord handle.
 std::string g_Hostname = ""; // 1-15 characters, https://support.microsoft.com/en-us/help/909264/naming-conventions-in-active-directory-for-computers-domains-sites-and
+bool g_IsRegistrationCodeRequired = false;
 
 unsigned char g_SessionHash[16] = { 0 }; // Session variable
 

--- a/xiloader/network.cpp
+++ b/xiloader/network.cpp
@@ -32,6 +32,7 @@ extern std::string g_Username;
 extern std::string g_Password;
 extern std::string g_ServerPort;
 extern std::string g_Hostname;
+extern bool g_IsRegistrationCodeRequired;
 extern unsigned char g_SessionHash[16];
 extern char* g_CharacterList;
 extern bool g_IsRunning;
@@ -259,7 +260,9 @@ namespace xiloader
             xiloader::console::output(xiloader::color::grey, "==========================================================");
             xiloader::console::output(xiloader::color::lightgreen, "What would you like to do?");
             xiloader::console::output(xiloader::color::lightcyan, "   1.) Login");
-            xiloader::console::output(xiloader::color::white, "   2.) Create Account (requires registration code)");
+            g_IsRegistrationCodeRequired
+                ? xiloader::console::output(xiloader::color::white, "   2.) Create Account (requires registration code)")
+                : xiloader::console::output(xiloader::color::white, "   2.) Create Account");
             xiloader::console::output(xiloader::color::grey, "   3.) Quit");
             xiloader::console::output(xiloader::color::grey, "==========================================================");
             printf("\nEnter a selection: ");
@@ -283,10 +286,12 @@ namespace xiloader
             else if (input == "2")
             {
                 console::output(color::lightyelllow, "Please enter the required information to create an account.");
-                console::output(color::lightyelllow, "To obtain a registration code visit Eden's Discord channel.");
-
-                std::cout << "Registration Code                : ";
-                std::cin >> registrationCode;
+                if (g_IsRegistrationCodeRequired)
+                {
+                    console::output(color::lightyelllow, "To obtain a registration code visit Eden's Discord channel.");
+                    std::cout << "Registration Code                : ";
+                    std::cin >> registrationCode;
+                }
 
             retry_email_2:
                 std::cout << "E-mail (used for password reset) : ";

--- a/xiloader/network.cpp
+++ b/xiloader/network.cpp
@@ -248,6 +248,22 @@ namespace xiloader
                 return false;
         }
 
+        /* Query server for login options. This should be backward compatible. */
+        send(sock->s, sendBuffer, 4, 0);
+        if (recv(sock->s, recvBuffer, 4, 0) < 0) {
+            closesocket(sock->s);
+            sock->s = INVALID_SOCKET;
+
+            xiloader::console::output(xiloader::color::error, "Failed to connect to server!");
+            std::cout << "Press the ENTER key to close...";
+            getline(std::cin, registrationCode);
+            exit(0);
+        }
+        else if (recvBuffer[0] == 1)
+        {
+            g_IsRegistrationCodeRequired = true;
+        }
+
         /* Determine if we should auto-login.. */
         bool bUseAutoLogin = !g_Username.empty() && !g_Password.empty() && bFirstLogin;
         if (bUseAutoLogin)


### PR DESCRIPTION
This supports the lobby server's optional registration code process. This is change was written to be backward compatible with the previous bootloaders that are in circulation.

I tested creating an account with a valid code when registration code was required. I made sure that the original console output was displayed. I also tested creating an account when a registration code was not required. I made sure that the new console output was displayed.